### PR TITLE
Ct 1306 fix retry config

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,11 @@ parameters:
     checkMissingIterableValueType: false
     excludePaths:
         - vendor
+    ignoreErrors:
+       - message: '#^Method PHPUnitRetry\\Tests\\RetryAnnotationTraitTest::([a-zA-Z0-9_]+)\(\) is unused\.$#'
+         path: %currentWorkingDirectory%/tests/RetryAnnotationTraitTest.php
+       - message: '#^Method PHPUnitRetry\\Tests\\RetryTraitTest::([a-zA-Z_]+)\(\) is unused\.$#'
+         path: %currentWorkingDirectory%/tests/RetryTraitTest.php
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/src/Util/ConfigFile.php
+++ b/src/Util/ConfigFile.php
@@ -6,10 +6,14 @@ final class ConfigFile
 {
     public static function getConfigFilename(): string
     {
-        $cwd = getcwd() . \DIRECTORY_SEPARATOR;
+        $reflection = new \ReflectionClass(\Composer\Autoload\ClassLoader::class);
+        $fileName = $reflection->getFileName();
+        assert(is_string($fileName), 'ReflectionClass::getFileName() returns string');
+        $vendorDir = dirname(dirname($fileName));
 
-        if (file_exists($cwd . 'phpunit-retry.xml')) {
-            $configFilename = $cwd . 'phpunit-retry.xml';
+        $projectRoot = dirname($vendorDir);
+        if (file_exists($projectRoot . \DIRECTORY_SEPARATOR . 'phpunit-retry.xml')) {
+            $configFilename = $projectRoot . \DIRECTORY_SEPARATOR . 'phpunit-retry.xml';
         } else {
             return dirname(__FILE__) . \DIRECTORY_SEPARATOR . 'phpunit-retry.xml';
         }

--- a/tests/Utils/ConfigTest.php
+++ b/tests/Utils/ConfigTest.php
@@ -44,7 +44,7 @@ class ConfigTest extends TestCase
     public function testMissingFile(): void
     {
         $this->expectException(Exception::class);
-        $this->expectErrorMessage('Could not read "missing-file.xml".');
+        $this->expectExceptionMessage('Could not read "missing-file.xml".');
         Config::getInstance('missing-file.xml');
     }
 }


### PR DESCRIPTION
JIRA: CT-1306

Fixuje to ze sa nepouzije config v roote takze to robi defaultne 3x retry

vyskusat to ide tu https://github.com/keboola/php-storage-driver-bigquery/pull/118 ked naistalujem composer s touto dev branch a pustim `testInfoSchemaNotExists` tak sa nespravi retrym ked to upravim v `phpunit-retry.xml` lokalne v BQ driveru tak to bude retrajovat podla toho kolko si tam nastavim